### PR TITLE
faster proximity check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 test/
 notebooks/
+logs/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/


### PR DESCRIPTION
A faster proximity check without pymatgen. The example of generating 10 mofs went from taking about 8 seconds to about 0.6 seconds.